### PR TITLE
Workaround for memory leak that can occur in tmux

### DIFF
--- a/SGE/qmonitor.sh
+++ b/SGE/qmonitor.sh
@@ -14,7 +14,7 @@ if [ "$#" -eq 1 ]; then
 fi
 
 while true; do
-    clear
+    clear && printf '\e[3J'
     python ./qavail.py "$TO_MONITOR"
     echo
     qstat -g c


### PR DESCRIPTION
Tmux sessions will consume memory endlessly as qmonitor creates infinite history -- this can be worked around via clearing the screen+history every time.